### PR TITLE
Update item and weapon themes

### DIFF
--- a/resources/items/experience.tres
+++ b/resources/items/experience.tres
@@ -1,12 +1,12 @@
 [gd_resource type="Resource" script_class="Item" load_steps=3 format=3 uid="uid://c4ew36sfl85ym"]
 
 [ext_resource type="Script" uid="uid://bfx11j545xbf5" path="res://scripts/data/item.gd" id="1_wkabm"]
-[ext_resource type="Theme" uid="uid://cgbnpl6hlm7s2" path="res://assets/button_themes/regular/green_button.tres" id="2_wkabm"]
+[ext_resource type="Theme" uid="uid://dqwm8agt87lsh" path="res://assets/button_themes/regular/blue_button.tres" id="2_v24x7"]
 
 [resource]
 script = ExtResource("1_wkabm")
 name = "Experience"
 description = "A small amount of experience"
-theme = ExtResource("2_wkabm")
+theme = ExtResource("2_v24x7")
 value = 1
 metadata/_custom_type_script = "uid://bfx11j545xbf5"

--- a/resources/items/gold.tres
+++ b/resources/items/gold.tres
@@ -1,12 +1,10 @@
 [gd_resource type="Resource" script_class="Item" load_steps=3 format=3 uid="uid://bjglrp2dbax4l"]
 
 [ext_resource type="Script" uid="uid://bfx11j545xbf5" path="res://scripts/data/item.gd" id="1_hfngv"]
-[ext_resource type="Theme" uid="uid://e6xnt81pte22" path="res://assets/button_themes/regular/gray_button.tres" id="2_dyt3x"]
+[ext_resource type="Theme" uid="uid://phfh7c5hwx1n" path="res://assets/button_themes/regular/yellow_button.tres" id="2_hhmvb"]
 
 [resource]
 script = ExtResource("1_hfngv")
 name = "Gold"
-description = ""
-theme = ExtResource("2_dyt3x")
-value = 0
+theme = ExtResource("2_hhmvb")
 metadata/_custom_type_script = "uid://bfx11j545xbf5"

--- a/resources/weapons/royal_scepter.tres
+++ b/resources/weapons/royal_scepter.tres
@@ -3,15 +3,13 @@
 [ext_resource type="Script" uid="uid://b2o7w8q10stxo" path="res://scripts/data/ability.gd" id="1_d0s14"]
 [ext_resource type="Script" uid="uid://dgykeyxn7fefw" path="res://scripts/data/weapon.gd" id="2_80lcv"]
 [ext_resource type="Resource" uid="uid://c4swar2v4ekyg" path="res://resources/abilities/magic_bolt.tres" id="2_kyn8k"]
-[ext_resource type="Theme" uid="uid://130ubmqd1h3b" path="res://assets/button_themes/regular/red_button.tres" id="3_kyn8k"]
 [ext_resource type="Resource" uid="uid://c815l0ks56vfs" path="res://resources/abilities/healing_light.tres" id="3_rgjqt"]
+[ext_resource type="Theme" uid="uid://cn00sxx7cmfjh" path="res://assets/button_themes/regular/pink_button.tres" id="5_kyn8k"]
 
 [resource]
 script = ExtResource("2_80lcv")
 rarity = "Rare"
 abilities = Array[ExtResource("1_d0s14")]([ExtResource("2_kyn8k"), ExtResource("3_rgjqt")])
 name = "Royal Scepter"
-description = ""
-theme = ExtResource("3_kyn8k")
-value = 0
+theme = ExtResource("5_kyn8k")
 metadata/_custom_type_script = "uid://dgykeyxn7fefw"


### PR DESCRIPTION
Changed the button themes for experience, gold, and royal scepter resources to use new color schemes. This improves visual consistency and updates the appearance of these items in the UI.