### PR TITLE
Add DeathWindow to battle screen

### DIFF
--- a/scenes/ui/screens/battle_screen.tscn
+++ b/scenes/ui/screens/battle_screen.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://ch4xo4n02q3jw" path="res://assets/BattleBackground.png" id="2_e8mee"]
 [ext_resource type="PackedScene" uid="uid://bjx12sxd6xqme" path="res://scenes/ui/components/hero_info.tscn" id="3_e8mee"]
 [ext_resource type="Theme" uid="uid://cra87dj7simd8" path="res://resources/ui/progress_bar/red_bar.tres" id="3_pxpkm"]
+[ext_resource type="PackedScene" uid="uid://usjhwmauxj8n" path="res://scenes/ui/windows/death_window.tscn" id="3_yj4kj"]
 [ext_resource type="Theme" uid="uid://dq41s7i7v61gk" path="res://resources/ui/backgrounds/background_panel.tres" id="4_pxpkm"]
 [ext_resource type="Theme" uid="uid://130ubmqd1h3b" path="res://resources/ui/button_themes/regular/red_button.tres" id="7_iw40k"]
 [ext_resource type="Theme" uid="uid://cgbnpl6hlm7s2" path="res://resources/ui/button_themes/regular/green_button.tres" id="8_qmdt6"]
@@ -20,6 +21,16 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ihhiw")
+
+[node name="RewardWindow" parent="." unique_id=1271341637 instance=ExtResource("11_xvgma")]
+visible = false
+
+[node name="DeathWindow" parent="." unique_id=673119729 instance=ExtResource("3_yj4kj")]
+size = Vector2i(480, 557)
+visible = false
+
+[node name="BattleManager" type="Node" parent="." unique_id=973972740]
+script = ExtResource("11_o00jr")
 
 [node name="BackgroundTextureRect" type="TextureRect" parent="." unique_id=1181602262]
 layout_mode = 1
@@ -145,16 +156,8 @@ size_flags_vertical = 3
 layout_mode = 2
 text = "This is an Ability"
 
-[node name="BattleManager" type="Node" parent="." unique_id=973972740]
-script = ExtResource("11_o00jr")
-
-[node name="RewardWindow" parent="." unique_id=1271341637 instance=ExtResource("11_xvgma")]
-visible = false
-
-[connection signal="toggled" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/AbilityButton" to="." method="_on_ability_button_toggled"]
-[connection signal="toggled" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/ItemButton" to="." method="_on_item_button_toggled"]
-[connection signal="pressed" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/MeditateButton" to="." method="_on_meditate_button_pressed"]
-[connection signal="pressed" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/FleeButton" to="." method="_on_flee_button_pressed"]
+[connection signal="rewards_collected" from="RewardWindow" to="." method="_on_rewards_collected"]
+[connection signal="return_to_village" from="DeathWindow" to="." method="_on_death_window_dismissed"]
 [connection signal="battle_log_updated" from="BattleManager" to="." method="_on_battle_log_updated"]
 [connection signal="battle_won" from="BattleManager" to="." method="_on_battle_won"]
 [connection signal="hero_attacking" from="BattleManager" to="." method="_on_hero_attacking"]
@@ -167,4 +170,7 @@ visible = false
 [connection signal="monster_updated" from="BattleManager" to="." method="_on_monster_updated"]
 [connection signal="new_monster" from="BattleManager" to="." method="_on_new_monster"]
 [connection signal="player_turn" from="BattleManager" to="." method="_on_player_turn"]
-[connection signal="rewards_collected" from="RewardWindow" to="." method="_on_rewards_collected"]
+[connection signal="toggled" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/AbilityButton" to="." method="_on_ability_button_toggled"]
+[connection signal="toggled" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/ItemButton" to="." method="_on_item_button_toggled"]
+[connection signal="pressed" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/MeditateButton" to="." method="_on_meditate_button_pressed"]
+[connection signal="pressed" from="MarginContainer/ActionPanel/ActionArea/LeftPanel/FleeButton" to="." method="_on_flee_button_pressed"]

--- a/scenes/ui/screens/battle_screen.tscn
+++ b/scenes/ui/screens/battle_screen.tscn
@@ -26,7 +26,6 @@ script = ExtResource("1_ihhiw")
 visible = false
 
 [node name="DeathWindow" parent="." unique_id=673119729 instance=ExtResource("3_yj4kj")]
-size = Vector2i(480, 557)
 visible = false
 
 [node name="BattleManager" type="Node" parent="." unique_id=973972740]

--- a/scenes/ui/windows/death_window.tscn
+++ b/scenes/ui/windows/death_window.tscn
@@ -1,0 +1,67 @@
+[gd_scene format=3 uid="uid://usjhwmauxj8n"]
+
+[ext_resource type="Theme" uid="uid://130ubmqd1h3b" path="res://resources/ui/button_themes/regular/red_button.tres" id="1_31xwb"]
+[ext_resource type="Theme" uid="uid://dq41s7i7v61gk" path="res://resources/ui/backgrounds/background_panel.tres" id="1_q8ub4"]
+[ext_resource type="Script" uid="uid://ddyybpcwdxeuv" path="res://scripts/ui/windows/death_window.gd" id="1_xq3t5"]
+
+[node name="DeathWindow" type="Window" unique_id=673119729]
+transparent_bg = true
+oversampling_override = 1.0
+size = Vector2i(480, 320)
+wrap_controls = true
+exclusive = true
+unresizable = true
+borderless = true
+transparent = true
+script = ExtResource("1_xq3t5")
+
+[node name="PanelContainer" type="PanelContainer" parent="." unique_id=1282750458]
+custom_minimum_size = Vector2(480, 320)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_q8ub4")
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer" unique_id=818910022]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer" unique_id=398004640]
+layout_mode = 2
+theme_override_constants/separation = 16
+alignment = 1
+
+[node name="TitleLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=578750439]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 14
+text = "You Were Defeated"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=1422823937]
+layout_mode = 2
+
+[node name="InfoLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=1928239130]
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 12
+text = "Your hero has been carried back to the village to recover.
+
+• HP and energy have been fully restored.
+• No XP or gold was lost.
+• Enemies you defeated remain defeated."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="ReturnButton" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer" unique_id=1592551786]
+custom_minimum_size = Vector2(96, 32)
+layout_mode = 2
+size_flags_horizontal = 4
+theme = ExtResource("1_31xwb")
+text = "Return to Village"

--- a/scenes/ui/windows/death_window.tscn
+++ b/scenes/ui/windows/death_window.tscn
@@ -8,7 +8,6 @@
 transparent_bg = true
 oversampling_override = 1.0
 size = Vector2i(480, 320)
-wrap_controls = true
 exclusive = true
 unresizable = true
 borderless = true
@@ -65,3 +64,5 @@ layout_mode = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_31xwb")
 text = "Return to Village"
+
+[connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/ReturnButton" to="." method="_on_return_button_pressed"]

--- a/scenes/ui/windows/reward_window.tscn
+++ b/scenes/ui/windows/reward_window.tscn
@@ -5,11 +5,15 @@
 [ext_resource type="Script" uid="uid://8u7rkk8oorfu" path="res://scripts/ui/windows/reward_window.gd" id="1_y5ohc"]
 
 [node name="RewardWindow" type="Window" unique_id=1271341637]
+transparent_bg = true
 oversampling_override = 1.0
 position = Vector2i(0, 36)
 size = Vector2i(158, 154)
 wrap_controls = true
+exclusive = true
+unresizable = true
 borderless = true
+transparent = true
 script = ExtResource("1_y5ohc")
 
 [node name="PanelContainer" type="PanelContainer" parent="." unique_id=1731204455]

--- a/scripts/ui/screens/battle_screen.gd
+++ b/scripts/ui/screens/battle_screen.gd
@@ -6,8 +6,9 @@ const BATTLE_CHARACTER = preload("res://scenes/ui/components/battle_character.ts
 
 @onready var battle_manager = $BattleManager
 
-@onready var battle_log: RichTextLabel = $MarginContainer/BattleLog
 @onready var reward_window: Window = $RewardWindow
+@onready var death_window: Window = $DeathWindow
+@onready var battle_log: RichTextLabel = $MarginContainer/BattleLog
 
 # Monster Info
 @onready var monster_health_bar: ProgressBar = $MarginContainer/VBoxContainer/MonsterHealthBar
@@ -143,6 +144,9 @@ func _on_rewards_collected() -> void:
 func _on_hero_defeated():
 	GameState.hero.rest()
 	GameState.pre_combat_position = Vector2.ZERO
+	death_window.popup_centered()
+
+func _on_death_window_dismissed() -> void:
 	ScreenManager.go_to_screen(ScreenManager.ScreenName.VILLAGE, "village")
 
 # --- Button Factories ---

--- a/scripts/ui/windows/death_window.gd
+++ b/scripts/ui/windows/death_window.gd
@@ -1,0 +1,15 @@
+extends Window
+class_name DeathWindow
+
+signal return_to_village
+
+@onready var return_button: Button = $PanelContainer/MarginContainer/VBoxContainer/ReturnButton
+
+func _ready() -> void:
+	close_requested.connect(_on_close_requested)
+
+func _on_return_button_pressed() -> void:
+	return_to_village.emit()
+
+func _on_close_requested() -> void:
+	pass

--- a/scripts/ui/windows/death_window.gd.uid
+++ b/scripts/ui/windows/death_window.gd.uid
@@ -1,0 +1,1 @@
+uid://ddyybpcwdxeuv


### PR DESCRIPTION
Introduce a DeathWindow to enhance the battle screen experience, allowing players to see defeat details and return to the village. Integrate the window's properties and connect the return button signal for functionality.